### PR TITLE
refactor Test Code - apply TSET_F & Mock

### DIFF
--- a/EmployeeDB/EmployeeDB/Adder.cpp
+++ b/EmployeeDB/EmployeeDB/Adder.cpp
@@ -3,7 +3,7 @@
 #include "DataStructure.h"
 #include "Parser.h"
 
-Adder::Adder(DataBase* dataBase) {
+Adder::Adder(IDataBase* dataBase) {
 	m_dataBase = dataBase;
 }
 

--- a/EmployeeDB/EmployeeDB/Adder.h
+++ b/EmployeeDB/EmployeeDB/Adder.h
@@ -1,13 +1,13 @@
 #pragma once
 #include <string>
 
-#include "DataBase.h"
+#include "IDataBase.h"
 
 class Adder
 {
 public:
-	Adder(DataBase* dataBase);
+	Adder(IDataBase* dataBase);
 	void Add(string employeeNum, string name, string cl, string phoneNum, string birthday, string certi);
 private:
-	DataBase* m_dataBase;
+	IDataBase* m_dataBase;
 };

--- a/EmployeeDB/EmployeeDB/DataBase.h
+++ b/EmployeeDB/EmployeeDB/DataBase.h
@@ -3,17 +3,17 @@
 #include <vector>
 #include <string>
 
+#include "IDataBase.h"
 #include "DataStructure.h"
 
-class DataBase
+class DataBase : public IDataBase
 {
 public:
-	void CreateRecord(Employee employee);
-	Employee ReadRecord(int index);
-	void UpdateRecord(int index, string data, KeyType keyType);
-	void DeleteRecord(int index);
-
-	vector<int> FindMapAll(KeyType keyType, string key);
+	void CreateRecord(Employee employee) override;
+	Employee ReadRecord(int index) override;
+	void UpdateRecord(int index, string data, KeyType keyType) override;
+	void DeleteRecord(int index) override;
+	vector<int> FindMapAll(KeyType keyType, string key) override;
 private:
 	struct Employee m_memberList[100000];
 

--- a/EmployeeDB/EmployeeDB/Deleter.cpp
+++ b/EmployeeDB/EmployeeDB/Deleter.cpp
@@ -3,7 +3,7 @@
 
 #include "DataStructure.h"
 
-Deleter::Deleter(DataBase* dataBase, Printer* printer) {
+Deleter::Deleter(IDataBase* dataBase, IPrinter* printer) {
 	m_dataBase = dataBase;
 	m_printer = printer;
 }

--- a/EmployeeDB/EmployeeDB/Deleter.h
+++ b/EmployeeDB/EmployeeDB/Deleter.h
@@ -6,10 +6,10 @@
 class Deleter
 {
 public:
-	Deleter(DataBase* dataBase, Printer* printer);
+	Deleter(IDataBase* dataBase, IPrinter* printer);
 	int Delete(OptionType option1, OptionType option2, KeyType type, string key);
 private:
-	DataBase* m_dataBase;
-	Printer* m_printer;
+	IDataBase* m_dataBase;
+	IPrinter* m_printer;
 };
 

--- a/EmployeeDB/EmployeeDB/EmployeeDB.vcxproj
+++ b/EmployeeDB/EmployeeDB/EmployeeDB.vcxproj
@@ -142,6 +142,7 @@
     <ClCompile Include="Adder.cpp" />
     <ClCompile Include="DataBase.cpp" />
     <ClCompile Include="Deleter.cpp" />
+    <ClCompile Include="IDataBase.h" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="Modifier.cpp" />
     <ClCompile Include="Parser.cpp" />
@@ -153,6 +154,7 @@
     <ClInclude Include="DataBase.h" />
     <ClInclude Include="DataStructure.h" />
     <ClInclude Include="Deleter.h" />
+    <ClInclude Include="IPrinter.h" />
     <ClInclude Include="Modifier.h" />
     <ClInclude Include="Parser.h" />
     <ClInclude Include="Printer.h" />

--- a/EmployeeDB/EmployeeDB/EmployeeDB.vcxproj.filters
+++ b/EmployeeDB/EmployeeDB/EmployeeDB.vcxproj.filters
@@ -39,6 +39,9 @@
     <ClCompile Include="Printer.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>
+    <ClCompile Include="IDataBase.h">
+      <Filter>헤더 파일</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="DataStructure.h">
@@ -63,6 +66,9 @@
       <Filter>헤더 파일</Filter>
     </ClInclude>
     <ClInclude Include="Printer.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="IPrinter.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
   </ItemGroup>

--- a/EmployeeDB/EmployeeDB/IDataBase.h
+++ b/EmployeeDB/EmployeeDB/IDataBase.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <vector>
+#include <string>
+
+#include "DataStructure.h"
+
+class IDataBase
+{
+public:
+	virtual void CreateRecord(Employee employee) = 0;
+	virtual Employee ReadRecord(int index) = 0;
+	virtual void UpdateRecord(int index, string data, KeyType keyType) = 0;
+	virtual void DeleteRecord(int index) = 0;
+	virtual vector<int> FindMapAll(KeyType keyType, string key) = 0;
+private:
+};

--- a/EmployeeDB/EmployeeDB/IPrinter.h
+++ b/EmployeeDB/EmployeeDB/IPrinter.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <string>
+#include <fstream>
+
+using namespace std;
+
+class IPrinter
+{
+public:
+	virtual void PrintRecord(string cmd, string employNum, string name, string cl, string phoneNum, string birthday, string certi) = 0;
+	virtual void PrintCount(string cmd, int recordCount) = 0;
+	virtual void PrintNone(string cmd) = 0;
+private:
+};
+

--- a/EmployeeDB/EmployeeDB/Modifier.cpp
+++ b/EmployeeDB/EmployeeDB/Modifier.cpp
@@ -1,6 +1,6 @@
 #include "Modifier.h"
 
-Modifier::Modifier(DataBase* dataBase, Printer* printer) {
+Modifier::Modifier(IDataBase* dataBase, IPrinter* printer) {
 	m_dataBase = dataBase;
 	m_printer = printer;
 }

--- a/EmployeeDB/EmployeeDB/Modifier.h
+++ b/EmployeeDB/EmployeeDB/Modifier.h
@@ -2,16 +2,16 @@
 #include <algorithm>
 #include <iostream>
 
-#include "DataBase.h"
-#include "Printer.h"
+#include "IDataBase.h"
+#include "IPrinter.h"
 #include "DataStructure.h"
 #include "Parser.h"
 
 class Modifier
 {
 public:
-	Modifier(DataBase* dataBase, Printer* m_printer);
+	Modifier(IDataBase* dataBase, IPrinter* m_printer);
 	bool Modify(KeyType condType, string condData, KeyType modType, string modData, OptionType option1, OptionType option2);
-	DataBase* m_dataBase;
-	Printer* m_printer;
+	IDataBase* m_dataBase;
+	IPrinter* m_printer;
 };

--- a/EmployeeDB/EmployeeDB/Parser.cpp
+++ b/EmployeeDB/EmployeeDB/Parser.cpp
@@ -31,7 +31,7 @@ bool compare(Employee a, Employee b) {
 		greator = true;
 	}
 	else {
-		cout << "[Fail] wrong EmployNum Range" << endl;
+		// cout << "[Fail] wrong EmployNum Range" << endl;
 	}
 
 	return greator;
@@ -79,7 +79,7 @@ void Parser::ParseCmdLine(string line, OUT CmdPacket& cmdPacket) {
 			cmdPacket.data6 = word;
 		}
 		else {
-			cout << "[Fail] intput data Cmd format error" << endl;
+			// cout << "[Fail] intput data Cmd format error" << endl;
 		}
 
 		wordIndex++;
@@ -101,7 +101,7 @@ void Parser::ParseName(string name, OUT string& firstName, string& lastName) {
 			lastName = word;
 		}
 		else {
-			cout << "[Fail] intput data Name format error" << endl;
+			// cout << "[Fail] intput data Name format error" << endl;
 		}
 		wordIndex++;
 	}
@@ -125,7 +125,7 @@ void Parser::ParsePhoneNum(string phoneNum, OUT string& middlePhoneNum, OUT stri
 			lastPhoneNum = word;
 		}
 		else {
-			cout << "[Fail] intput data PhoneNum format error" << endl;
+			// cout << "[Fail] intput data PhoneNum format error" << endl;
 		}
 		wordIndex++;
 	}
@@ -147,7 +147,7 @@ void Parser::ParseBirthDay(string birthDay, OUT string& year, OUT string& month,
 			day += ch;
 		}
 		else {
-			cout << "[Fail] intput data BirthDay format error" << endl;
+			// cout << "[Fail] intput data BirthDay format error" << endl;
 		}
 	}
 }
@@ -178,7 +178,7 @@ OptionType Parser::ParseOption(string option) {
 		optionType = OptionType::none;
 	}
 	else {
-		cout << "[Fail] intput data Option format error" << endl;
+		// cout << "[Fail] intput data Option format error" << endl;
 	}
 
 	return optionType;
@@ -210,7 +210,7 @@ KeyType Parser::TranslateKeyType(string keyname) {
 		keyType = KeyType::Certi;
 	}
 	else {
-		cout << "[Fail] wrong key name" << endl;
+		// cout << "[Fail] wrong key name" << endl;
 	}
 
 	return keyType;

--- a/EmployeeDB/EmployeeDB/Printer.h
+++ b/EmployeeDB/EmployeeDB/Printer.h
@@ -3,15 +3,17 @@
 #include <string>
 #include <fstream>
 
+#include "IPrinter.h"
+
 using namespace std;
 
-class Printer
+class Printer : public IPrinter
 {
 public:
 	Printer(ofstream* ofs);
-	void PrintRecord(string cmd, string employNum, string name, string cl, string phoneNum, string birthday, string certi);
-	void PrintCount(string cmd, int recordCount);
-	void PrintNone(string cmd);
+	void PrintRecord(string cmd, string employNum, string name, string cl, string phoneNum, string birthday, string certi) override;
+	void PrintCount(string cmd, int recordCount) override;
+	void PrintNone(string cmd) override;
 private:
 	ofstream* m_outfileStream;
 };

--- a/EmployeeDB/EmployeeDB/Searcher.cpp
+++ b/EmployeeDB/EmployeeDB/Searcher.cpp
@@ -1,7 +1,7 @@
 #include "Searcher.h"
 #include "Parser.h"
 
-Searcher::Searcher(DataBase* dataBase, Printer* printer) {
+Searcher::Searcher(IDataBase* dataBase, IPrinter* printer) {
 	m_dataBase = dataBase;
 	m_Printer = printer;
 	m_comm = "SCH";

--- a/EmployeeDB/EmployeeDB/Searcher.h
+++ b/EmployeeDB/EmployeeDB/Searcher.h
@@ -1,20 +1,20 @@
 #pragma once
 
-#include "DataBase.h"
-#include "Printer.h"
+#include "IDataBase.h"
+#include "IPrinter.h"
 #include <Algorithm>
 #include "Parser.h"
 
 class Searcher
 {
 public:
-	Searcher(DataBase* dataBase, Printer* printer);
+	Searcher(IDataBase* dataBase, IPrinter* printer);
 	bool Search(KeyType keyType, string key, OptionType ot, OptionType ot2);
 	bool isNumber(const string& str);
 
 private:
-	DataBase* m_dataBase;
-	Printer* m_Printer;
+	IDataBase* m_dataBase;
+	IPrinter* m_Printer;
 	string m_comm;
 
 	bool CallPrinter(Employee employee);

--- a/EmployeeDB/EmployeeDB/main.cpp
+++ b/EmployeeDB/EmployeeDB/main.cpp
@@ -12,6 +12,7 @@
 #include "Modifier.h"
 #include "Printer.h"
 
+
 int main(int argc, char* argv[]) {
 
 	string inputFileName = argv[1];
@@ -46,16 +47,6 @@ int main(int argc, char* argv[]) {
 				string certi = cmdPacket.data6;
 
 				adder->Add(employNum, name, cl, phoneNumber, birthday, certi);
-
-				// for debug
-				//cout << "--------------------------" << endl;
-				//cout << "ADDED" << endl;
-				//cout << employNum << endl;
-				//cout << name << endl;
-				//cout << cl << endl;
-				//cout << phoneNumber << endl;
-				//cout << birthday << endl;
-				//cout << certi << endl;
 			}
 			else if (cmdPacket.cmd.compare("DEL") == 0) {
 				OptionType option1 = Parser::ParseOption(cmdPacket.option1);
@@ -64,14 +55,6 @@ int main(int argc, char* argv[]) {
 				string keyData = cmdPacket.data2;
 
 				deleter->Delete(option1, option2, keyType, keyData);
-
-				// for debug
-				//cout << "--------------------------" << endl;
-				//cout << "DELETED" << endl;
-				//cout << (int)(option1) << endl;
-				//cout << (int)option2 << endl;
-				//cout << (int)keyType << endl;
-				//cout << keyData << endl;
 			}
 			else if (cmdPacket.cmd.compare("SCH") == 0) {
 				OptionType option1 = Parser::ParseOption(cmdPacket.option1);
@@ -80,15 +63,6 @@ int main(int argc, char* argv[]) {
 				string keyData = cmdPacket.data2;
 
 				searcher->Search(keyType, keyData, option1, option2);
-
-				//// for debug
-				//cout << "--------------------------" << endl;
-				//cout << "SEARCHED" << endl;
-				//cout << (int)(option1) << endl;
-				//cout << (int)option2 << endl;
-				//cout << (int)keyType << endl;
-				//cout << keyData << endl;
-
 			}
 			else if (cmdPacket.cmd.compare("MOD") == 0) {
 				OptionType option1 = Parser::ParseOption(cmdPacket.option1);
@@ -99,26 +73,15 @@ int main(int argc, char* argv[]) {
 				string modData = cmdPacket.data4;
 
 				modifier->Modify(keyType, keyData, modType, modData, option1, option2);
-
-				// for debug
-				//cout << "--------------------------" << endl;
-				//cout << "MODIFIED" << endl;
-				//cout << (int)(option1) << endl;
-				//cout << (int)option2 << endl;
-				//cout << (int)keyType << endl;
-				//cout << keyData << endl;
-				//cout << (int)modType << endl;
-				//cout << modData << endl;
-
 			}
 			else {
-				cout << "[Fail] wrong command input" << endl;
+				// cout << "[Fail] wrong command input" << endl;
 				break;
 			}
 		}
 	}
 	else {
-		cout << "[Fail] File does not exists" << endl;
+		// cout << "[Fail] File does not exists" << endl;
 	}
 
 	ifs.close();

--- a/EmployeeDB/Test_Project/AdderTest.cpp
+++ b/EmployeeDB/Test_Project/AdderTest.cpp
@@ -1,10 +1,32 @@
 #include "pch.h"
-#include "../EmployeeDB/Adder.h"
-#include "../EmployeeDB/DataBase.h"
+#include "gmock/gmock.h"
 
-TEST(AdderTest, AddTest) {
-	DataBase* db = new DataBase();
-	Adder* adder = new Adder(db);
+#include "../EmployeeDB/Adder.h"
+#include "../EmployeeDB/IDataBase.h"
+
+#include "MockDataBase.h"
+
+using namespace testing;
+
+class AdderTest : public testing::Test
+{
+protected:
+	void SetUp(void) override {
+		mockDataBase = new MockDataBase();
+		adder = new Adder(mockDataBase);
+	}
+
+	void TearDown(void) override {
+		delete mockDataBase;
+		delete adder;
+	}
+
+	MockDataBase* mockDataBase;
+	Adder* adder;
+};
+
+
+TEST_F(AdderTest, AddTest) {
 
 	string employeeNum = "15123099";
 	string name = "VXIHXOTH JHOP";;
@@ -13,25 +35,7 @@ TEST(AdderTest, AddTest) {
 	string birthday = "19771211";
 	string certi = "ADV";
 
+	EXPECT_CALL(*mockDataBase, CreateRecord(_)).Times(1);
+
 	adder->Add(employeeNum, name, cl, phoneNum, birthday, certi);
-
-	Employee res = db->ReadRecord(0);
-	EXPECT_EQ(true, res.valid);
-	EXPECT_EQ(0, res.employeeNum.compare("15123099"));
-
-	EXPECT_EQ(0, res.name.compare("VXIHXOTH JHOP"));
-	EXPECT_EQ(0, res.firstName.compare("VXIHXOTH"));
-	EXPECT_EQ(0, res.lastName.compare("JHOP"));
-	EXPECT_EQ(0, res.cl.compare("CL3"));
-
-	EXPECT_EQ(0, res.phoneNum.compare("010-3112-2609"));
-	EXPECT_EQ(0, res.middlePhoneNum.compare("3112"));
-	EXPECT_EQ(0, res.lastPhoneNum.compare("2609"));
-
-	EXPECT_EQ(0, res.birthday.compare("19771211"));
-	EXPECT_EQ(0, res.yearBirth.compare("1977"));
-	EXPECT_EQ(0, res.monthBirth.compare("12"));
-	EXPECT_EQ(0, res.dayBirth.compare("11"));
-
-	EXPECT_EQ(0, res.certi.compare("ADV"));
 }

--- a/EmployeeDB/Test_Project/DataBaseTest.cpp
+++ b/EmployeeDB/Test_Project/DataBaseTest.cpp
@@ -1,28 +1,85 @@
 #include "pch.h"
 #include "../EmployeeDB/DataBase.h"
 #include "../EmployeeDB/DataStructure.h"
-TEST(DataBaseTest, ReadTest) {
-	DataBase* database = new DataBase();
+#include <vector>
 
-	Employee employee1;
+using namespace testing;
 
-	employee1.employeeNum = "15123099";
-	employee1.name = "VXIHXOTH JHOP";
-	employee1.cl = "CL3";
-	employee1.phoneNum = "010-3112-2609";
-	employee1.birthday = "19771211";
-	employee1.certi = "ADV";
-	employee1.valid = true;
+class DataBaseTest : public testing::Test
+{
+protected:
+	void SetUp(void) override {
+		database = new DataBase();
 
-	Employee employee2;
+		Employee employee1;
 
-	employee2.employeeNum = "17112609";
-	employee2.name = "FB NTAWR";
-	employee2.cl = "CL4";
-	employee2.phoneNum = "010-5645-6122";
-	employee2.birthday = "19861203";
-	employee2.certi = "PRO";
-	employee2.valid = true;
+		employee1.employeeNum = "15123099";
+		employee1.name = "VXIHXOTH JHOP";
+		employee1.cl = "CL3";
+		employee1.phoneNum = "010-3112-2609";
+		employee1.birthday = "19771211";
+		employee1.certi = "ADV";
+		employee1.valid = true;
+		employee1.firstName = "VXIHXOTH";
+		employee1.lastName = "JHOP";
+		employee1.middlePhoneNum = "3112";
+		employee1.lastPhoneNum = "2609";
+		employee1.yearBirth = "1977";
+		employee1.monthBirth = "12";
+		employee1.dayBirth = "11";
+
+		Employee employee2;
+
+		employee2.employeeNum = "17112609";
+		employee2.name = "FB NTAWR";
+		employee2.cl = "CL4";
+		employee2.phoneNum = "010-5645-6122";
+		employee2.birthday = "19861203";
+		employee2.certi = "PRO";
+		employee2.valid = true;
+		employee2.firstName = "FB";
+		employee2.lastName = "NTAWR";
+		employee2.middlePhoneNum = "5645";
+		employee2.lastPhoneNum = "6122";
+		employee2.yearBirth = "1986";
+		employee2.monthBirth = "12";
+		employee2.dayBirth = "03";
+
+		Employee employee3;
+
+		employee3.employeeNum = "18115040";
+		employee3.name = "TTETHU HBO";
+		employee3.cl = "CL3";
+		employee3.phoneNum = "010-4581-2050";
+		employee3.birthday = "20080718";
+		employee3.certi = "ADV";
+		employee3.valid = true;
+
+		employee3.firstName = "TTETHU";
+		employee3.lastName = "HBO";
+		employee3.middlePhoneNum = "4581";
+		employee3.lastPhoneNum = "2050";
+		employee3.yearBirth = "2008";
+		employee3.monthBirth = "07";
+		employee3.dayBirth = "18";
+
+		employeeVec.push_back(employee1);
+		employeeVec.push_back(employee2);
+		employeeVec.push_back(employee3);
+
+	}
+
+	void TearDown(void) override {
+
+	}
+
+	IDataBase* database;
+	vector<Employee> employeeVec;
+};
+TEST_F(DataBaseTest, ReadTest) {
+
+	Employee employee1 = employeeVec.at(0);
+	Employee employee2 = employeeVec.at(1);
 
 	database->CreateRecord(employee1);
 	database->CreateRecord(employee2);
@@ -35,19 +92,9 @@ TEST(DataBaseTest, ReadTest) {
 	EXPECT_EQ(0, res2.phoneNum.compare("010-5645-6122"));
 	EXPECT_FALSE(res3.valid);
 }
-TEST(DataBaseTest, UpdateTest) {
+TEST_F(DataBaseTest, UpdateTest) {
 
-	DataBase* database = new DataBase();
-
-	Employee employee;
-
-	employee.employeeNum = "15123099";
-	employee.name = "VXIHXOTH JHOP";
-	employee.cl = "CL3";
-	employee.phoneNum = "010-3112-2609";
-	employee.birthday = "19771211";
-	employee.certi = "ADV";
-	employee.valid = true;
+	Employee employee = employeeVec.at(0);
 
 	database->CreateRecord(employee);
 
@@ -63,18 +110,10 @@ TEST(DataBaseTest, UpdateTest) {
 	EXPECT_EQ(0, res.cl.compare("CL4"));
 }
 
-TEST(DataBaseTest, DeleteTest) {
-	DataBase* database = new DataBase();
+TEST_F(DataBaseTest, DeleteTest) {
 
-	Employee employee;
+	Employee employee = employeeVec.at(0);
 
-	employee.employeeNum = "15123099";
-	employee.name = "VXIHXOTH JHOP";
-	employee.cl = "CL3";
-	employee.phoneNum = "010-3112-2609";
-	employee.birthday = "19771211";
-	employee.certi = "ADV";
-	employee.valid = true;
 
 	database->CreateRecord(employee);
 
@@ -87,38 +126,11 @@ TEST(DataBaseTest, DeleteTest) {
 	EXPECT_EQ(false, res.valid);
 }
 
-TEST(DataBaseTest, FindAllTest) {
-	DataBase* database = new DataBase();
+TEST_F(DataBaseTest, FindAllTest) {
 
-	Employee employee1;
-
-	employee1.employeeNum = "15123099";
-	employee1.name = "VXIHXOTH JHOP";
-	employee1.cl = "CL3";
-	employee1.phoneNum = "010-3112-2609";
-	employee1.birthday = "19771211";
-	employee1.certi = "ADV";
-	employee1.valid = true;
-
-	Employee employee2;
-
-	employee2.employeeNum = "17112609";
-	employee2.name = "FB NTAWR";
-	employee2.cl = "CL4";
-	employee2.phoneNum = "010-5645-6122";
-	employee2.birthday = "19861203";
-	employee2.certi = "PRO";
-	employee2.valid = true;
-
-	Employee employee3;
-
-	employee3.employeeNum = "18115040";
-	employee3.name = "TTETHU HBO";
-	employee3.cl = "CL3";
-	employee3.phoneNum = "010-4581-2050";
-	employee3.birthday = "20080718";
-	employee3.certi = "ADV";
-	employee3.valid = true;
+	Employee employee1 = employeeVec.at(0);
+	Employee employee2 = employeeVec.at(1);
+	Employee employee3 = employeeVec.at(2);
 
 	database->CreateRecord(employee1);
 	database->CreateRecord(employee2);
@@ -129,62 +141,12 @@ TEST(DataBaseTest, FindAllTest) {
 	EXPECT_EQ(2, resVec.size());
 }
 
-TEST(DataBaseTest, OptionDataTest) {
-	DataBase* database = new DataBase();
+TEST_F(DataBaseTest, OptionDataTest) {
 
-	Employee employee1;
+	Employee employee1 = employeeVec.at(0);
+	Employee employee2 = employeeVec.at(1);
+	Employee employee3 = employeeVec.at(2);
 
-	employee1.employeeNum = "15123099";
-	employee1.name = "VXIHXOTH JHOP";
-	employee1.cl = "CL3";
-	employee1.phoneNum = "010-3112-2609";
-	employee1.birthday = "19771211";
-	employee1.certi = "ADV";
-	employee1.valid = true;
-
-	employee1.firstName = "VXIHXOTH";
-	employee1.lastName = "JHOP";
-	employee1.middlePhoneNum = "3112";
-	employee1.lastPhoneNum = "2609";
-	employee1.yearBirth = "1977";
-	employee1.monthBirth = "12";
-	employee1.dayBirth = "11";
-
-	Employee employee2;
-
-	employee2.employeeNum = "17112609";
-	employee2.name = "FB NTAWR";
-	employee2.cl = "CL4";
-	employee2.phoneNum = "010-5645-6122";
-	employee2.birthday = "19861203";
-	employee2.certi = "PRO";
-	employee2.valid = true;
-
-	employee2.firstName = "FB";
-	employee2.lastName = "NTAWR";
-	employee2.middlePhoneNum = "5645";
-	employee2.lastPhoneNum = "6122";
-	employee2.yearBirth = "1986";
-	employee2.monthBirth = "12";
-	employee2.dayBirth = "03";
-
-	Employee employee3;
-
-	employee3.employeeNum = "18115040";
-	employee3.name = "TTETHU HBO";
-	employee3.cl = "CL3";
-	employee3.phoneNum = "010-4581-2050";
-	employee3.birthday = "20080718";
-	employee3.certi = "ADV";
-	employee3.valid = true;
-
-	employee3.firstName = "TTETHU";
-	employee3.lastName = "HBO";
-	employee3.middlePhoneNum = "4581";
-	employee3.lastPhoneNum = "2050";
-	employee3.yearBirth = "2008";
-	employee3.monthBirth = "07";
-	employee3.dayBirth = "18";
 
 	database->CreateRecord(employee1);
 	database->CreateRecord(employee2);

--- a/EmployeeDB/Test_Project/DeleterTest.cpp
+++ b/EmployeeDB/Test_Project/DeleterTest.cpp
@@ -5,166 +5,124 @@
 #include "../EmployeeDB/Printer.h"
 #include "../EmployeeDB/Parser.h"
 
+#include "MockPrinter.h"
 
+using namespace testing;
 
-TEST(DeleteTest, BasicTest) {
-	DataBase* database = new DataBase();
-	ofstream ofs;
-
-	string outFileName = "output_test.txt";
-	ofs.open(outFileName);
-
-	Printer* printer = new Printer(&ofs);
-	Deleter deleter(database, printer);
-
-	Employee list[7];
-	list[0] = {true, "00000000", "JIHOON KIM", "CL2", "010-0000-0000", "970319", "PRO"};
-	list[1] = {true, "00000001", "DONGWOO KIM", "CL2", "010-0000-0001", "970320", "PRO"};
-	list[2] = {true, "00000002", "JOONGHYUN KIM", "CL2", "010-0000-0002", "970321", "PRO"};
-	list[3] = {true, "00000003", "DONGIL LEE", "CL3", "010-0000-0003", "970322", "PRO"};
-	list[4] = {true, "00000004", "SEUNGJI GWAK", "CL4", "010-0000-0004", "970323", "PRO"};
-	list[5] = {true, "00000005", "YOUNGDOO KIM", "CL3", "010-0000-0005", "970324", "PRO"};
-	list[6] = {true, "00000006", "JUNSEOK YANG", "CL4", "010-0000-0006", "970325", "EX"};
-
-	for (int i = 0; i < 7; i++)
-	{
-		database->CreateRecord(list[i]);
-	}
-	
-	EXPECT_EQ(deleter.Delete(OptionType::none, OptionType::none, KeyType::EmployeeNum, list[0].employeeNum), 1);
-	EXPECT_EQ(deleter.Delete(OptionType::none, OptionType::none, KeyType::Name, list[1].name), 1);
-	EXPECT_EQ(deleter.Delete(OptionType::none, OptionType::none, KeyType::Cl, list[2].cl), 1);
-	EXPECT_EQ(deleter.Delete(OptionType::none, OptionType::none, KeyType::PhoneNum, list[3].phoneNum), 1);
-	EXPECT_EQ(deleter.Delete(OptionType::none, OptionType::none, KeyType::Birthday, list[4].birthday), 1);
-	EXPECT_EQ(deleter.Delete(OptionType::none, OptionType::none, KeyType::Certi, list[5].certi), 1);
-	ofs.close();
-	std::remove(outFileName.c_str());
-}
-
-
-TEST(DeleteTest, Option2Test) {
-	DataBase* database = new DataBase();
-	ofstream ofs;
-
-	string outFileName = "output_test.txt";
-	ofs.open(outFileName);
-
-	Printer* printer = new Printer(&ofs);
-	Deleter deleter(database, printer);
-
-	Employee list[7];
-	list[0] = { true, "00000000", "JIHOON KIM", "CL2", "010-0000-0000", "970319", "PRO", "JIHOON", "KIM", "0000", "0000", "97", "03", "19"};
-	list[1] = { true, "00000001", "DONGWOO PARK", "CL2", "010-0000-0001", "970320", "PRO", "DONGWOO", "PARK", "0000", "0001", "97", "03", "20" };
-	list[2] = { true, "00000002", "JOONGHYUN KIM", "CL2", "010-0010-0002", "970321", "PRO", "JOONGHYUN", "KIM", "0010", "0002", "97", "03", "21" };
-	list[3] = { true, "00000003", "DONGIL LEE", "CL3", "010-0000-0003", "970322", "PRO", "DONGIL", "LEE", "0000", "0003", "97", "03", "22" };
-	list[4] = { true, "00000004", "SEUNGJI GWAK", "CL4", "010-0000-0004", "970323", "PRO", "SEUNGJI", "GWAK", "0000", "0004", "97", "03", "23" };
-	list[5] = { true, "00000005", "YOUNGDOO KIM", "CL3", "010-0000-0005", "980424", "PRO", "YOUNGDOO", "KIM", "0000", "0005", "98", "04", "24" };
-	list[6] = { true, "00000006", "JUNSEOK YANG", "CL4", "010-0000-0006", "990525", "EX", "JUNSEOK", "YANG", "0000", "0006", "99", "05", "25" };
-
-	for (int i = 0; i < 7; i++)
-	{
-		database->CreateRecord(list[i]);
-	}
-
-	EXPECT_EQ(deleter.Delete(OptionType::none, OptionType::f, KeyType::Name,"JIHOON"),1);
-	EXPECT_EQ(deleter.Delete(OptionType::none, OptionType::l, KeyType::Name, "PARK"), 1);
-
-	EXPECT_EQ(deleter.Delete(OptionType::none, OptionType::m, KeyType::PhoneNum, "0010"), 1);
-	EXPECT_EQ(deleter.Delete(OptionType::none, OptionType::l, KeyType::PhoneNum, "0003"), 1);
-
-	EXPECT_EQ(deleter.Delete(OptionType::none, OptionType::y, KeyType::Birthday, "97"), 1);
-	EXPECT_EQ(deleter.Delete(OptionType::none, OptionType::m, KeyType::Birthday, "04"), 1);
-	EXPECT_EQ(deleter.Delete(OptionType::none, OptionType::d, KeyType::Birthday, "25"), 1);
-	ofs.close();
-	std::remove(outFileName.c_str());
-}
-
-
-
-TEST(DeleteTest, Option1Test)
+class DeleterTest : public testing::Test
 {
-	DataBase* database = new DataBase();
+protected:
+	void SetUp(void) override {
+		database = new DataBase();
+		mockPrinter = new MockPrinter();
+		deleter = new Deleter(database, mockPrinter);
 
-	ofstream ofs;
+		list[0] = { true, "00000000", "JIHOON KIM", "CL2", "010-0000-0000", "19970319", "PRO", "JIHOON", "KIM", "0000", "0000", "1997", "03", "19" };
+		list[1] = { true, "00000001", "DONGWOO PARK", "CL2", "010-0000-0001", "19970320", "PRO", "DONGWOO", "PARK", "0000", "0001", "1997", "03", "20" };
+		list[2] = { true, "00000002", "JOONGHYUN KIM", "CL2", "010-0010-0002", "19970321", "PRO", "JOONGHYUN", "KIM", "0010", "0002", "1997", "03", "21" };
+		list[3] = { true, "00000003", "DONGIL LEE", "CL3", "010-0000-0003", "19970322", "PRO", "DONGIL", "LEE", "0000", "0003", "97", "1903", "22" };
+		list[4] = { true, "00000004", "SEUNGJI GWAK", "CL4", "010-0000-0004", "19970323", "PRO", "SEUNGJI", "GWAK", "0000", "0004", "1997", "03", "23" };
+		list[5] = { true, "00000005", "YOUNGDOO KIM", "CL3", "010-0000-0005", "19980424", "PRO", "YOUNGDOO", "KIM", "0000", "0005", "1998", "04", "24" };
+		list[6] = { true, "00000006", "JUNSEOK YANG", "CL4", "010-0000-0006", "19990525", "EX", "JUNSEOK", "YANG", "0000", "0006", "1999", "05", "25" };
 
-	string outFileName = "output_test.txt";
-	ofs.open(outFileName);
+		for (int i = 0; i < 7; i++)
+		{
+			database->CreateRecord(list[i]);
+		}
+	}
 
-	Printer* printer = new Printer(&ofs);
-	Deleter deleter(database, printer);
+	void TearDown(void) override {
+		delete database;
+		delete mockPrinter;
+		delete deleter;
+	}
+
+	DataBase* database;
+	Deleter* deleter;
+	MockPrinter* mockPrinter;
 
 	Employee list[7];
-	list[0] = { true, "69000000", "JIHOON KIM", "CL2", "010-0000-0000", "970319", "PRO", "JIHOON", "KIM", "0000", "0000", "97", "03", "19" };
-	list[1] = { true, "69000001", "DONGWOO PARK", "CL2", "010-0000-0001", "970320", "PRO", "DONGWOO", "PARK", "0000", "0001", "97", "03", "20" };
-	list[2] = { true, "70000002", "JOONGHYUN KIM", "CL2", "010-0010-0002", "970321", "PRO", "JOONGHYUN", "KIM", "0010", "0002", "97", "03", "21" };
-	list[3] = { true, "70000003", "DONGIL LEE", "CL2", "010-0000-0003", "970322", "PRO", "DONGIL", "LEE", "0000", "0003", "97", "03", "22" };
-	list[4] = { true, "19000004", "SEUNGJI GWAK", "CL2", "010-0000-0004", "970323", "PRO", "SEUNGJI", "GWAK", "0000", "0004", "97", "03", "23" };
-	list[5] = { true, "20000005", "YOUNGDOO KIM", "CL2", "010-0000-0005", "980424", "PRO", "YOUNGDOO", "KIM", "0000", "0005", "98", "04", "24" };
-	list[6] = { true, "21000006", "JUNSEOK YANG", "CL2", "010-0000-0006", "990525", "EX", "JUNSEOK", "YANG", "0000", "0006", "99", "05", "25" };
 
-	for (int i = 0; i < 7; i++)
-	{
-		database->CreateRecord(list[i]);
-	}
+};
+TEST_F(DeleterTest, BasicTest) {
+	
+	EXPECT_CALL(*mockPrinter, PrintRecord("DEL", _, _, _, _, _, _)).Times(0);
+	EXPECT_CALL(*mockPrinter, PrintNone("DEL")).Times(1);
+	EXPECT_CALL(*mockPrinter, PrintCount("DEL", _)).Times(6);
 
-	EXPECT_EQ(7,deleter.Delete(OptionType::p, OptionType::none, KeyType::Cl, "CL2"));
-	EXPECT_EQ(0,deleter.Delete(OptionType::p, OptionType::none, KeyType::Cl, "CL2"));
+	int res0 = deleter->Delete(OptionType::none, OptionType::none, KeyType::EmployeeNum, "99999999");
+	EXPECT_EQ(res0, 0);
 
-	string expected1 = "DEL,69000000,JIHOON KIM,CL2,010-0000-0000,970319,PRO";
-	string expected2 = "DEL,69000001,DONGWOO PARK,CL2,010-0000-0001,970320,PRO";
-	string expected3 = "DEL,70000002,JOONGHYUN KIM,CL2,010-0010-0002,970321,PRO";
-	string expected4 = "DEL,70000003,DONGIL LEE,CL2,010-0000-0003,970322,PRO";
-	string expected5 = "DEL,19000004,SEUNGJI GWAK,CL2,010-0000-0004,970323,PRO";
-	string expected6 = "DEL,NONE";
-	ofs.close();
+	int res1 = deleter->Delete(OptionType::none, OptionType::none, KeyType::EmployeeNum, list[0].employeeNum);
+	EXPECT_EQ(res1, 1);
 
-	ifstream ifs;
+	int res2 = deleter->Delete(OptionType::none, OptionType::none, KeyType::Name, list[1].name);
+	EXPECT_EQ(res2, 1);
 
-	ifs.open(outFileName);
+	int res3 = deleter->Delete(OptionType::none, OptionType::none, KeyType::Cl, list[2].cl);
+	EXPECT_EQ(res3, 1);
 
-	string line;
+	int res4 = deleter->Delete(OptionType::none, OptionType::none, KeyType::PhoneNum, list[3].phoneNum);
+	EXPECT_EQ(res4, 1);
 
-	string res1;
-	string res2;
-	string res3;
-	string res4;
-	string res5;
-	string res6;
+	int res5 = deleter->Delete(OptionType::none, OptionType::none, KeyType::Birthday, list[4].birthday);
+	EXPECT_EQ(res5, 1);
 
+	int res6 = deleter->Delete(OptionType::none, OptionType::none, KeyType::Certi, list[5].certi);
+	EXPECT_EQ(res6, 1);
 
-	int index = 0;
-	while (getline(ifs, line)) {
-		if (index == 0) {
-			res1 = line;
-		}
-		else if (index == 1) {
-			res2 = line;
-		}
-		else if (index == 2) {
-			res3 = line;
-		}
-		else if (index == 3) {
-			res4 = line;
-		}
-		else if (index == 4) {
-			res5 = line;
-		}
-		else if (index == 5) {
-			res6 = line;
-		}
-
-		index++;
-	}
-
-	EXPECT_EQ(0, res1.compare(expected1));
-	EXPECT_EQ(0, res2.compare(expected2));
-	EXPECT_EQ(0, res3.compare(expected3));
-	EXPECT_EQ(0, res4.compare(expected4));
-	EXPECT_EQ(0, res5.compare(expected5));
-	EXPECT_EQ(0, res6.compare(expected6));
-	EXPECT_EQ(res6, expected6);
-
-
-	ifs.close();
-	std::remove(outFileName.c_str());
 }
+
+
+TEST_F(DeleterTest, Option1Test)
+{
+	EXPECT_CALL(*mockPrinter, PrintRecord("DEL", _, _, _, _, _, _)).Times(7);
+	EXPECT_CALL(*mockPrinter, PrintNone("DEL")).Times(1);
+	EXPECT_CALL(*mockPrinter, PrintCount("DEL", _)).Times(0);
+
+	int res0 = deleter->Delete(OptionType::p, OptionType::none, KeyType::Cl, "CL2");
+	EXPECT_EQ(res0, 3);
+	
+	int res1 = deleter->Delete(OptionType::p, OptionType::none, KeyType::Certi, "PRO");
+	EXPECT_EQ(res1, 3);
+
+	int res2 = deleter->Delete(OptionType::p, OptionType::none, KeyType::Cl, "CL4");
+	EXPECT_EQ(res2, 1);
+
+	int res3 = deleter->Delete(OptionType::p, OptionType::none, KeyType::Cl, "CL3");
+	EXPECT_EQ(res3, 0);
+
+}
+TEST_F(DeleterTest, Option2Test) {
+
+
+	EXPECT_CALL(*mockPrinter, PrintRecord("DEL", _, _, _, _, _, _)).Times(0);
+	EXPECT_CALL(*mockPrinter, PrintNone("DEL")).Times(1);
+	EXPECT_CALL(*mockPrinter, PrintCount("DEL", _)).Times(7);
+
+	int res0 = deleter->Delete(OptionType::none, OptionType::f, KeyType::Name, "JIHOON");
+	EXPECT_EQ(res0, 1);
+
+	int res1 = deleter->Delete(OptionType::none, OptionType::f, KeyType::Name, "JIHOON");
+	EXPECT_EQ(res1, 0);
+
+	int res2 = deleter->Delete(OptionType::none, OptionType::l, KeyType::Name, "PARK");
+	EXPECT_EQ(res2, 1);
+
+	int res3 = deleter->Delete(OptionType::none, OptionType::m, KeyType::PhoneNum, "0010");
+	EXPECT_EQ(res3, 1);
+
+	int res4 = deleter->Delete(OptionType::none, OptionType::l, KeyType::PhoneNum, "0003");
+	EXPECT_EQ(res4, 1);
+
+	int res5 = deleter->Delete(OptionType::none, OptionType::y, KeyType::Birthday, "1997");
+	EXPECT_EQ(res5, 1);
+
+	int res6 = deleter->Delete(OptionType::none, OptionType::m, KeyType::Birthday, "04");
+	EXPECT_EQ(res6, 1);
+
+	int res7 = deleter->Delete(OptionType::none, OptionType::d, KeyType::Birthday, "25");
+	EXPECT_EQ(res7, 1);
+
+}
+

--- a/EmployeeDB/Test_Project/MockDataBase.h
+++ b/EmployeeDB/Test_Project/MockDataBase.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "pch.h"
+#include "gmock/gmock.h"
+
+#include "../EmployeeDB/IDataBase.h"
+
+using namespace testing;
+
+class MockDataBase : public IDataBase
+{
+public:
+	MOCK_METHOD(void, CreateRecord, (Employee employee), (override));
+	MOCK_METHOD(Employee, ReadRecord, (int index), (override));
+	MOCK_METHOD(void, UpdateRecord, (int index, string data, KeyType keyType), (override));
+	MOCK_METHOD(void, DeleteRecord, (int index), (override));
+	MOCK_METHOD(vector<int>, FindMapAll, (KeyType keyType, string key), (override));
+};

--- a/EmployeeDB/Test_Project/MockPrinter.h
+++ b/EmployeeDB/Test_Project/MockPrinter.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "pch.h"
+#include "gmock/gmock.h"
+
+#include "../EmployeeDB/IPrinter.h"
+
+using namespace testing;
+
+class MockPrinter : public IPrinter
+{
+public:
+	MOCK_METHOD(void, PrintRecord, (string cmd, string employNum, string name, string cl, string phoneNum, string birthday, string certi), (override));
+	MOCK_METHOD(void, PrintCount, (string cmd, int recordCount), (override));
+	MOCK_METHOD(void, PrintNone, (string cmd), (override));
+};

--- a/EmployeeDB/Test_Project/ModifierTest.cpp
+++ b/EmployeeDB/Test_Project/ModifierTest.cpp
@@ -2,187 +2,124 @@
 #include "../EmployeeDB/Adder.h"
 #include "../EmployeeDB/Modifier.h"
 #include "../EmployeeDB/DataBase.h"
+#include "../EmployeeDB/IPrinter.h"
 
+#include "MockPrinter.h"
 
-TEST(ModifierTest, ModTest) {
-	DataBase* db = new DataBase();
-	Adder* adder = new Adder(db);
-	ofstream writeFile;
-	writeFile.open("test.txt");
-	Printer* printer = new Printer(&writeFile);
-	Modifier* modifier = new Modifier(db, printer);
+using namespace testing;
 
-	string employeeNum = "15123099";
-	string name = "VXIHXOTH JHOP";
-	string cl = "CL3";
-	string phoneNum = "010-3112-2609";
-	string birthday = "19771211";
-	string certi = "ADV";
+class ModifierTest : public testing::Test
+{
+protected:
+	void SetUp(void) override {
+		database = new DataBase();
+		mockPrinter = new MockPrinter();
+		modifier = new Modifier(database, mockPrinter);
 
-	adder->Add(employeeNum, name, cl, phoneNum, birthday, certi);
+		list[0] = { true, "00000000", "JIHOON KIM", "CL2", "010-0000-0000", "19970319", "PRO", "JIHOON", "KIM", "0000", "0000", "1997", "03", "19" };
+		list[1] = { true, "00000001", "DONGWOO PARK", "CL2", "010-0000-0001", "19970320", "PRO", "DONGWOO", "PARK", "0000", "0001", "1997", "03", "20" };
+		list[2] = { true, "00000002", "JOONGHYUN KIM", "CL2", "010-0010-0002", "19970321", "PRO", "JOONGHYUN", "KIM", "0010", "0002", "1997", "03", "21" };
+		list[3] = { true, "00000003", "DONGIL LEE", "CL3", "010-0000-0003", "19970322", "PRO", "DONGIL", "LEE", "0000", "0003", "97", "1903", "22" };
+		list[4] = { true, "00000004", "SEUNGJI GWAK", "CL4", "010-0000-0004", "19970323", "PRO", "SEUNGJI", "GWAK", "0000", "0004", "1997", "03", "23" };
+		list[5] = { true, "00000005", "YOUNGDOO KIM", "CL3", "010-0000-0005", "19980424", "PRO", "YOUNGDOO", "KIM", "0000", "0005", "1998", "04", "24" };
+		list[6] = { true, "00000006", "JUNSEOK YANG", "CL4", "010-0000-0006", "19990525", "EX", "JUNSEOK", "YANG", "0000", "0006", "1999", "05", "25" };
 
-	employeeNum = "21123099";
-	name = "VXIHXOTH HHOP";
-	cl = "CL3";
-	phoneNum = "010-1234-2609";
-	birthday = "19771212";
-	certi = "PRO";
+		for (int i = 0; i < 7; i++)
+		{
+			database->CreateRecord(list[i]);
+		}
+	}
 
-	adder->Add(employeeNum, name, cl, phoneNum, birthday, certi);
+	void TearDown(void) override {
+		delete database;
+		delete mockPrinter;
+		delete modifier;
+	}
+
+	DataBase* database;
+	Modifier* modifier;
+	MockPrinter* mockPrinter;
+
+	Employee list[7];
+
+};
+TEST_F(ModifierTest, BasicTest) {
+	EXPECT_CALL(*mockPrinter, PrintRecord("MOD", _, _, _, _, _, _)).Times(0);
+	EXPECT_CALL(*mockPrinter, PrintNone("MOD")).Times(0);
+	EXPECT_CALL(*mockPrinter, PrintCount("MOD", 2)).Times(1);
 
 	modifier->Modify(KeyType::Cl, "CL3", KeyType::Certi, "EX", OptionType::none, OptionType::none);
 
-	EXPECT_EQ("EX", db->ReadRecord(0).certi);
-	EXPECT_EQ("EX", db->ReadRecord(1).certi);
+	string expected1 = database->ReadRecord(3).certi;
+	string expected2 = database->ReadRecord(5).certi;
 
-	modifier->Modify(KeyType::Name, "VXIHXOTH HHOP", KeyType::Birthday, "20000101", OptionType::none, OptionType::none);
-	EXPECT_EQ("20000101", db->ReadRecord(1).birthday);
-	EXPECT_NE("20000101", db->ReadRecord(0).birthday);
-
-	//Test option 2
-	modifier->Modify(KeyType::Name, "HHOP", KeyType::Birthday, "21001101", OptionType::none, OptionType::l);
-	EXPECT_EQ("21001101", db->ReadRecord(1).birthday);
-
-	modifier->Modify(KeyType::Name, "VXIHXOTH", KeyType::Certi, "ADV", OptionType::none, OptionType::f);
-	EXPECT_EQ("ADV", db->ReadRecord(0).certi);
-	EXPECT_EQ("ADV", db->ReadRecord(1).certi);
-
-	//Test option 1
-	modifier->Modify(KeyType::Certi, "ADV", KeyType::Certi, "EX", OptionType::p, OptionType::none);
-
-	writeFile.close();
-
-	ifstream readFile;
-	string totalStr = "";
-	readFile.open("test.txt");
-	if (readFile.is_open())
-	{
-		while (!readFile.eof())
-		{
-			string str;
-			getline(readFile, str);
-			totalStr = totalStr + '\n' + str;
-		}
-		readFile.close();
-	}
-	EXPECT_EQ("\nMOD,2\nMOD,1\nMOD,1\nMOD,2\nMOD,15123099,VXIHXOTH JHOP,CL3,010-3112-2609,19771211,ADV\nMOD,21123099,VXIHXOTH HHOP,CL3,010-1234-2609,21001101,ADV\n", totalStr);
+	EXPECT_EQ(0, expected1.compare("EX"));
+	EXPECT_EQ(0, expected2.compare("EX"));
 }
 
-TEST(ModifierTest, OptionTest) {
-	DataBase* db = new DataBase();
-	Adder* adder = new Adder(db);
-	ofstream writeFile;
-	writeFile.open("test.txt");
-	Printer* printer = new Printer(&writeFile);
-	Modifier* modifier = new Modifier(db, printer);
+TEST_F(ModifierTest, Option1Test) {
+	EXPECT_CALL(*mockPrinter, PrintRecord("MOD", _, _, _, _, _, _)).Times(1);
+	EXPECT_CALL(*mockPrinter, PrintNone("MOD")).Times(0);
+	EXPECT_CALL(*mockPrinter, PrintCount("MOD", _)).Times(0);
 
-	string employeeNum = "15123099";
-	string name = "VXIHXOTH JHOP";
-	string cl = "CL3";
-	string phoneNum = "010-3112-2609";
-	string birthday = "19771211";
-	string certi = "ADV";
+	modifier->Modify(KeyType::Certi, "EX", KeyType::Cl, "CL1", OptionType::p, OptionType::none);
 
-	adder->Add(employeeNum, name, cl, phoneNum, birthday, certi);
+	string expected1 = database->ReadRecord(6).cl;
 
-	employeeNum = "21123099";
-	name = "Park HHOP";
-	cl = "CL3";
-	phoneNum = "010-1234-1234";
-	birthday = "19880912";
-	certi = "PRO";
+	EXPECT_EQ(0, expected1.compare("CL1"));
+}
 
-	adder->Add(employeeNum, name, cl, phoneNum, birthday, certi);
+TEST_F(ModifierTest, Option2Test) {
+	EXPECT_CALL(*mockPrinter, PrintRecord("MOD", _, _, _, _, _, _)).Times(1);
+	EXPECT_CALL(*mockPrinter, PrintNone("MOD")).Times(0);
+	EXPECT_CALL(*mockPrinter, PrintCount("MOD", _)).Times(0);
 
-	modifier->Modify(KeyType::EmployeeNum, "15123099", KeyType::Name, "Junseok Yoon", OptionType::p, OptionType::f);
+	modifier->Modify(KeyType::Name, "JUNSEOK", KeyType::Cl, "CL4", OptionType::p, OptionType::f);
 
-	
-	writeFile.close();
+	string expected1 = database->ReadRecord(6).cl;
 
-	ifstream readFile;
-	string totalStr = "";
+	EXPECT_EQ(0, expected1.compare("CL4"));
+}
+TEST_F(ModifierTest, ModifyNameTest) {
+	EXPECT_CALL(*mockPrinter, PrintRecord("MOD", _, _, _, _, _, _)).Times(1);
+	EXPECT_CALL(*mockPrinter, PrintNone("MOD")).Times(0);
+	EXPECT_CALL(*mockPrinter, PrintCount("MOD", _)).Times(0);
 
-	Employee res = db->ReadRecord(0);
+	modifier->Modify(KeyType::Name, "JUNSEOK", KeyType::Name, "CLEAN CODE", OptionType::p, OptionType::f);
 
-	EXPECT_EQ(res.firstName.compare("Junseok"), 0);
-	EXPECT_EQ(res.lastName.compare("Yoon"), 0);
-	
-	modifier->Modify(KeyType::EmployeeNum, "15123099", KeyType::PhoneNum, "010-8927-0425", OptionType::p, OptionType::none);
+	string expected1 = database->ReadRecord(6).firstName;
+	string expected2 = database->ReadRecord(6).lastName;
 
-	res = db->ReadRecord(0);
+	EXPECT_EQ(0, expected1.compare("CLEAN"));
+	EXPECT_EQ(0, expected2.compare("CODE"));
+}
 
-	EXPECT_EQ(res.middlePhoneNum.compare("8927"), 0);
-	EXPECT_EQ(res.lastPhoneNum.compare("0425"), 0);
+TEST_F(ModifierTest, ModifyPhoneNumTest) {
+	EXPECT_CALL(*mockPrinter, PrintRecord("MOD", _, _, _, _, _, _)).Times(1);
+	EXPECT_CALL(*mockPrinter, PrintNone("MOD")).Times(0);
+	EXPECT_CALL(*mockPrinter, PrintCount("MOD", _)).Times(0);
 
-	modifier->Modify(KeyType::EmployeeNum, "15123099", KeyType::Birthday, "19930317", OptionType::p, OptionType::none);
+	modifier->Modify(KeyType::Name, "JUNSEOK", KeyType::PhoneNum, "010-8927-0425", OptionType::p, OptionType::f);
 
-	res = db->ReadRecord(0);
+	string expected1 = database->ReadRecord(6).middlePhoneNum;
+	string expected2 = database->ReadRecord(6).lastPhoneNum;
 
-	EXPECT_EQ(res.yearBirth.compare("1993"), 0);
-	EXPECT_EQ(res.monthBirth.compare("03"), 0);
-	EXPECT_EQ(res.dayBirth.compare("17"), 0);
+	EXPECT_EQ(0, expected1.compare("8927"));
+	EXPECT_EQ(0, expected2.compare("0425"));
+}
+TEST_F(ModifierTest, ModifyBirthdayTest) {
+	EXPECT_CALL(*mockPrinter, PrintRecord("MOD", _, _, _, _, _, _)).Times(1);
+	EXPECT_CALL(*mockPrinter, PrintNone("MOD")).Times(0);
+	EXPECT_CALL(*mockPrinter, PrintCount("MOD", _)).Times(0);
 
+	modifier->Modify(KeyType::Name, "JUNSEOK", KeyType::Birthday, "19930317", OptionType::p, OptionType::f);
 
-
-	vector<int> resVector = db->FindMapAll(KeyType::FirstName, "Junseok");
-	EXPECT_EQ(1, resVector.size());
-
-	resVector = db->FindMapAll(KeyType::LastName, "Yoon");
-	EXPECT_EQ(1, resVector.size());
-
-	resVector = db->FindMapAll(KeyType::MiddlePhoneNum, "8927");
-	EXPECT_EQ(1, resVector.size());
-
-	resVector = db->FindMapAll(KeyType::LastPhoneNum, "0425");
-	EXPECT_EQ(1, resVector.size());
-
-	resVector = db->FindMapAll(KeyType::YearBirth, "1993");
-	EXPECT_EQ(1, resVector.size());
-
-	resVector = db->FindMapAll(KeyType::MonthBirth, "03");
-	EXPECT_EQ(1, resVector.size());
-
-	resVector = db->FindMapAll(KeyType::DayBirth, "17");
-	EXPECT_EQ(1, resVector.size());
-
-	resVector = db->FindMapAll(KeyType::Name, "Junseok Yoon");
-	EXPECT_EQ(1, resVector.size());
-
-	resVector = db->FindMapAll(KeyType::PhoneNum, "010-8927-0425");
-	EXPECT_EQ(1, resVector.size());
-
-	resVector = db->FindMapAll(KeyType::Birthday, "19930317");
-	EXPECT_EQ(1, resVector.size());
+	string expected1 = database->ReadRecord(6).yearBirth;
+	string expected2 = database->ReadRecord(6).monthBirth;
+	string expected3 = database->ReadRecord(6).dayBirth;
 
 
-	// check if former data is not erased
-	resVector = db->FindMapAll(KeyType::FirstName, "VXIHXOTH");
-	EXPECT_EQ(0, resVector.size());
-
-	resVector = db->FindMapAll(KeyType::LastName, "JHOP");
-	EXPECT_EQ(0, resVector.size());
-
-	resVector = db->FindMapAll(KeyType::MiddlePhoneNum, "3112");
-	EXPECT_EQ(0, resVector.size());
-
-	resVector = db->FindMapAll(KeyType::LastPhoneNum, "2609");
-	EXPECT_EQ(0, resVector.size());
-
-	resVector = db->FindMapAll(KeyType::YearBirth, "1977");
-	EXPECT_EQ(0, resVector.size());
-
-	resVector = db->FindMapAll(KeyType::MonthBirth, "12");
-	EXPECT_EQ(0, resVector.size());
-
-	resVector = db->FindMapAll(KeyType::DayBirth, "11");
-	EXPECT_EQ(0, resVector.size());
-
-	resVector = db->FindMapAll(KeyType::Name, "VXIHXOTH JHOP");
-	EXPECT_EQ(0, resVector.size());
-
-	resVector = db->FindMapAll(KeyType::PhoneNum, "010-3112-2609");
-	EXPECT_EQ(0, resVector.size());
-
-	resVector = db->FindMapAll(KeyType::Birthday, "19771211");
-	EXPECT_EQ(0, resVector.size());
+	EXPECT_EQ(0, expected1.compare("1993"));
+	EXPECT_EQ(0, expected2.compare("03"));
+	EXPECT_EQ(0, expected3.compare("17"));
 }

--- a/EmployeeDB/Test_Project/ParserTest.cpp
+++ b/EmployeeDB/Test_Project/ParserTest.cpp
@@ -2,7 +2,20 @@
 #include "../EmployeeDB/Parser.h"
 #include"../EmployeeDB/DataStructure.h"
 
-TEST(ParserTest, ParseCmdLineTest) {
+using namespace testing;
+
+class ParserTest : public testing::Test
+{
+protected:
+	void SetUp(void) override {
+
+	}
+
+	void TearDown(void) override {
+
+	}
+};
+TEST_F(ParserTest, ParseCmdLineTest) {
 	string str = "ADD, , , ,15123099,VXIHXOTH JHOP,CL3,010-3112-2609,19771211,ADV";
 
 	CmdPacket cmdPacket;
@@ -20,7 +33,7 @@ TEST(ParserTest, ParseCmdLineTest) {
 	EXPECT_EQ(0, cmdPacket.data6.compare("ADV"));
 }
 
-TEST(ParserTest, ParseNameTest) {
+TEST_F(ParserTest, ParseNameTest) {
 	string str = "VXIHXOTH JHOP";
 
 	string firstName;
@@ -31,7 +44,7 @@ TEST(ParserTest, ParseNameTest) {
 	EXPECT_EQ(0, lastName.compare("JHOP"));
 }
 
-TEST(ParserTest, ParsePhoneNumTest) {
+TEST_F(ParserTest, ParsePhoneNumTest) {
 	string str = "010-3112-2609";
 
 	string middlePhoneNum;
@@ -42,7 +55,7 @@ TEST(ParserTest, ParsePhoneNumTest) {
 	EXPECT_EQ(0, lastPhoneNum.compare("2609"));
 }
 
-TEST(ParserTest, ParseBirthDayTest) {
+TEST_F(ParserTest, ParseBirthDayTest) {
 	string str = "19771211";
 
 	string year;
@@ -56,7 +69,7 @@ TEST(ParserTest, ParseBirthDayTest) {
 
 }
 
-TEST(ParserTest, ParseOptionTest) {
+TEST_F(ParserTest, ParseOptionTest) {
 	string str = "-p";
 
 	OptionType optionType = Parser::ParseOption(str);
@@ -64,7 +77,7 @@ TEST(ParserTest, ParseOptionTest) {
 	EXPECT_EQ(OptionType::p, optionType);
 }
 
-TEST(ParserTest, SortEmployeeTest) {
+TEST_F(ParserTest, SortEmployeeTest) {
 	
 	vector<Employee> employVec;
 
@@ -95,7 +108,7 @@ TEST(ParserTest, SortEmployeeTest) {
 	EXPECT_EQ(0, youngestEmployee.employeeNum.compare("21999999"));
 }
 
-TEST(ParserTest, TranslateKeyTypeTest) {
+TEST_F(ParserTest, TranslateKeyTypeTest) {
 
 	KeyType keyType;
 
@@ -118,7 +131,7 @@ TEST(ParserTest, TranslateKeyTypeTest) {
 	EXPECT_EQ(KeyType::Certi, keyType);
 }
 
-TEST(ParserTest, ChangeConditionTest) {
+TEST_F(ParserTest, ChangeConditionTest) {
 	
 	EXPECT_EQ(KeyType::FirstName, Parser::ChangeCondition(KeyType::Name, OptionType::f));
 	EXPECT_EQ(KeyType::LastName, Parser::ChangeCondition(KeyType::Name, OptionType::l));

--- a/EmployeeDB/Test_Project/PrinterTest.cpp
+++ b/EmployeeDB/Test_Project/PrinterTest.cpp
@@ -5,27 +5,40 @@
 #include <string>
 #include "../EmployeeDB/Printer.h"
 
-TEST(PrinterTest, PrintTest) {
-	
+using namespace testing;
+
+class PrinterTest : public testing::Test
+{
+protected:
+	void SetUp(void) override {
+
+		ofs.open(outFileName);
+		printer = new Printer(&ofs);
+
+	}
+
+	void TearDown(void) override {
+		ofs.close();
+		ifs.close();
+		std::remove(outFileName.c_str());
+		delete printer;
+	}
+
 	ofstream ofs;
-
+	ifstream ifs;
+	Printer* printer;
 	string outFileName = "output_test.txt";
-	ofs.open(outFileName);
-
+};
+TEST_F(PrinterTest, PrintTest) {
+	
 	string expected1 = "MOD,17112609,FB NTAWR,CL4,010-5645-6122,19861203,PRO";
 	string expected2 = "SCH,NONE";
 	string expected3 = "DEL,1";
 
-	Printer printer(&ofs);
+	printer->PrintRecord("MOD", "17112609", "FB NTAWR", "CL4", "010-5645-6122", "19861203", "PRO");
+	printer->PrintNone("SCH");
+	printer->PrintCount("DEL", 1);
 
-	printer.PrintRecord("MOD", "17112609", "FB NTAWR", "CL4", "010-5645-6122", "19861203", "PRO");
-	printer.PrintNone("SCH");
-	printer.PrintCount("DEL", 1);
-
-	ofs.close();
-
-	ifstream ifs;
-	
 	ifs.open(outFileName);
 
 	string line;
@@ -52,7 +65,4 @@ TEST(PrinterTest, PrintTest) {
 	EXPECT_EQ(0, res1.compare(expected1));
 	EXPECT_EQ(0, res2.compare(expected2));
 	EXPECT_EQ(0, res3.compare(expected3));
-
-	ifs.close();
-	std::remove(outFileName.c_str());
 }

--- a/EmployeeDB/Test_Project/SearcherTest.cpp
+++ b/EmployeeDB/Test_Project/SearcherTest.cpp
@@ -2,28 +2,134 @@
 #include "../EmployeeDB/Searcher.h"
 #include "../EmployeeDB/DataBase.h"
 #include "../EmployeeDB/Printer.h"
-#include "../EmployeeDB/Adder.h"
 
-TEST(SearcherTest, TestName) {
+#include "MockPrinter.h"
 
-	ofstream ofs2;
-	ofs2.open("test.txt");
+using namespace testing;
 
-	DataBase* database = new DataBase();
-	Printer* printer = new Printer(&ofs2);
-	Searcher* searcher = new Searcher(database, printer);
-	Adder* adder = new Adder(database);
+class SearcherTest : public testing::Test
+{
+protected:
+	void SetUp(void) override {
+		database = new DataBase();
+		mockPrinter = new MockPrinter();
+		searcher = new Searcher(database, mockPrinter);
 
-	adder->Add("15123099", "JUNSEOK A", "CL4", "010-0006-0006", "19970325", "EX");
-	adder->Add("69000000", "JUNSEOK A", "CL4", "010-0006-0006", "19970325", "EX");
-	adder->Add("69000001", "JUNSEOK C", "CL4", "010-0002-0002", "19970427", "EX");
-	adder->Add("88114052", "JUNSEOK D", "CL4", "010-0006-0006", "19970527", "EX");
-	adder->Add("99999999", "JUNSEOK E", "CL4", "010-0006-0006", "19970626", "EX");
-	adder->Add("21999998", "JUNSEOK F", "CL4", "010-0003-0003", "19970727", "EX");
-	adder->Add("21999999", "JUNSEOK G", "CL4", "010-0002-0004", "19970825", "EX");
-	adder->Add("00000000", "JUNSEOK G", "CL4", "010-0007-0007", "19970925", "EX");
+		list[0] = { true, "15123099", "JUNSEOK A", "CL4", "010-0006-0006", "19970325", "EX", "JUNSEOK", "A", "0006", "0006", "1997", "03", "25" };
+		list[1] = { true, "69000000", "JUNSEOK A", "CL4", "010-0006-0006", "19970325", "EX", "JUNSEOK", "A", "0006", "0006", "1997", "03", "25" };
+		list[2] = { true, "69000001", "JUNSEOK C", "CL4", "010-0002-0002", "19970427", "EX", "JUNSEOK", "C", "0002", "0002", "1997", "04", "27" };
+		list[3] = { true, "88114052", "JUNSEOK D", "CL4", "010-0006-0006", "19970527", "EX", "JUNSEOK", "D", "0006", "0006", "1997", "05", "27" };
+		list[4] = { true, "99999999", "JUNSEOK E", "CL4", "010-0006-0006", "19970626", "EX", "JUNSEOK", "E", "0006", "0006", "1997", "06", "26" };
+		list[5] = { true, "21999998", "JUNSEOK F", "CL4", "010-0003-0003", "19970727", "EX", "JUNSEOK", "F", "0003", "0003", "1997", "07", "27" };
+		list[6] = { true, "21999999", "JUNSEOK G", "CL4", "010-0002-0004", "19970825", "EX", "JUNSEOK", "G", "0002", "0004", "1997", "08", "25" };
+		list[7] = { true, "00000000", "JUNSEOK G", "CL4", "010-0007-0007", "19970925", "EX", "JUNSEOK", "G", "0007", "0007", "1997", "09", "25" };
 
-	bool istrue = searcher->Search(KeyType::LastPhoneNum, "25", OptionType::p, OptionType::d);
-	EXPECT_EQ(istrue, true);
+		for (int i = 0; i < 8; i++)
+		{
+			database->CreateRecord(list[i]);
+		}
+	}
 
+	void TearDown(void) override {
+		delete database;
+		delete mockPrinter;
+		delete searcher;
+	}
+
+	DataBase* database;
+	Searcher* searcher;
+	MockPrinter* mockPrinter;
+
+	Employee list[8];
+
+};
+TEST_F(SearcherTest, BasicTest) {
+
+	EXPECT_CALL(*mockPrinter, PrintRecord("SCH", _, _, _, _, _, _)).Times(0);
+	EXPECT_CALL(*mockPrinter, PrintNone("SCH")).Times(0);
+	EXPECT_CALL(*mockPrinter, PrintCount("SCH", 8)).Times(1);
+
+	searcher->Search(KeyType::Cl, "CL4", OptionType::none, OptionType::none);
+}
+
+TEST_F(SearcherTest, BasicTest2) {
+
+	EXPECT_CALL(*mockPrinter, PrintRecord("SCH", _, _, _, _, _, _)).Times(0);
+	EXPECT_CALL(*mockPrinter, PrintNone("SCH")).Times(0);
+	EXPECT_CALL(*mockPrinter, PrintCount("SCH", 2)).Times(1);
+
+	searcher->Search(KeyType::Name, "JUNSEOK G", OptionType::none, OptionType::none);
+}
+
+TEST_F(SearcherTest, BasicTest3) {
+
+	EXPECT_CALL(*mockPrinter, PrintRecord("SCH", _, _, _, _, _, _)).Times(0);
+	EXPECT_CALL(*mockPrinter, PrintNone("SCH")).Times(1);
+	EXPECT_CALL(*mockPrinter, PrintCount("SCH", _)).Times(0);
+
+	searcher->Search(KeyType::Cl, "CL3", OptionType::none, OptionType::none);
+}
+
+
+TEST_F(SearcherTest, Option1Test)
+{
+	EXPECT_CALL(*mockPrinter, PrintRecord("SCH", _, _, _, _, _, _)).Times(5);
+	EXPECT_CALL(*mockPrinter, PrintNone("SCH")).Times(0);
+	EXPECT_CALL(*mockPrinter, PrintCount("SCH", _)).Times(0);
+
+	searcher->Search(KeyType::Cl, "CL4", OptionType::p, OptionType::none);
+}
+
+TEST_F(SearcherTest, Option1Test2)
+{
+	EXPECT_CALL(*mockPrinter, PrintRecord("SCH", _, _, _, _, _, _)).Times(4);
+	EXPECT_CALL(*mockPrinter, PrintNone("SCH")).Times(0);
+	EXPECT_CALL(*mockPrinter, PrintCount("SCH", _)).Times(0);
+
+	searcher->Search(KeyType::PhoneNum, "010-0006-0006", OptionType::p, OptionType::none);
+}
+
+TEST_F(SearcherTest, Option2Test) {
+
+	EXPECT_CALL(*mockPrinter, PrintRecord("SCH", _, _, _, _, _, _)).Times(5);
+	EXPECT_CALL(*mockPrinter, PrintNone("SCH")).Times(0);
+	EXPECT_CALL(*mockPrinter, PrintCount("SCH", _)).Times(0);
+
+	searcher->Search(KeyType::Name, "JUNSEOK", OptionType::p, OptionType::f);
+}
+
+TEST_F(SearcherTest, Option2Test2) {
+
+	EXPECT_CALL(*mockPrinter, PrintRecord("SCH", _, _, _, _, _, _)).Times(2);
+	EXPECT_CALL(*mockPrinter, PrintNone("SCH")).Times(0);
+	EXPECT_CALL(*mockPrinter, PrintCount("SCH", _)).Times(0);
+
+	searcher->Search(KeyType::Name, "G", OptionType::p, OptionType::l);
+}
+
+TEST_F(SearcherTest, Option2Test3) {
+
+	EXPECT_CALL(*mockPrinter, PrintRecord("SCH", _, _, _, _, _, _)).Times(4);
+	EXPECT_CALL(*mockPrinter, PrintNone("SCH")).Times(0);
+	EXPECT_CALL(*mockPrinter, PrintCount("SCH", _)).Times(0);
+
+	searcher->Search(KeyType::PhoneNum, "0006", OptionType::p, OptionType::m);
+}
+
+TEST_F(SearcherTest, Option2Test4) {
+
+	EXPECT_CALL(*mockPrinter, PrintRecord("SCH", _, _, _, _, _, _)).Times(1);
+	EXPECT_CALL(*mockPrinter, PrintNone("SCH")).Times(0);
+	EXPECT_CALL(*mockPrinter, PrintCount("SCH", _)).Times(0);
+
+	searcher->Search(KeyType::PhoneNum, "0003", OptionType::p, OptionType::l);
+}
+
+TEST_F(SearcherTest, Option2Test5) {
+
+	EXPECT_CALL(*mockPrinter, PrintRecord("SCH", _, _, _, _, _, _)).Times(4);
+	EXPECT_CALL(*mockPrinter, PrintNone("SCH")).Times(0);
+	EXPECT_CALL(*mockPrinter, PrintCount("SCH", _)).Times(0);
+
+	searcher->Search(KeyType::Birthday, "25", OptionType::p, OptionType::d);
 }

--- a/EmployeeDB/Test_Project/Test_Project.vcxproj
+++ b/EmployeeDB/Test_Project/Test_Project.vcxproj
@@ -33,6 +33,8 @@
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros" />
   <ItemGroup>
+    <ClInclude Include="MockDataBase.h" />
+    <ClInclude Include="MockPrinter.h" />
     <ClInclude Include="pch.h" />
   </ItemGroup>
   <ItemGroup>
@@ -62,6 +64,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.5\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets" Condition="Exists('..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.5\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets')" />
+    <Import Project="..\packages\gmock.1.11.0\build\native\gmock.targets" Condition="Exists('..\packages\gmock.1.11.0\build\native\gmock.targets')" />
   </ImportGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -80,13 +83,15 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>X64;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeaderOutputFile />
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -132,5 +137,6 @@
       <ErrorText>이 프로젝트는 이 컴퓨터에 없는 NuGet 패키지를 참조합니다. 해당 패키지를 다운로드하려면 NuGet 패키지 복원을 사용하십시오. 자세한 내용은 http://go.microsoft.com/fwlink/?LinkID=322105를 참조하십시오. 누락된 파일은 {0}입니다.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.5\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.5\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets'))" />
+    <Error Condition="!Exists('..\packages\gmock.1.11.0\build\native\gmock.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\gmock.1.11.0\build\native\gmock.targets'))" />
   </Target>
 </Project>

--- a/EmployeeDB/Test_Project/Test_Project.vcxproj.filters
+++ b/EmployeeDB/Test_Project/Test_Project.vcxproj.filters
@@ -26,6 +26,12 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
+    <ClInclude Include="MockDataBase.h">
+      <Filter>Test</Filter>
+    </ClInclude>
+    <ClInclude Include="MockPrinter.h">
+      <Filter>Test</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/EmployeeDB/Test_Project/packages.config
+++ b/EmployeeDB/Test_Project/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="gmock" version="1.11.0" targetFramework="native" />
   <package id="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" version="1.8.1.5" targetFramework="native" />
 </packages>


### PR DESCRIPTION
1. TC 코드를 모두 TEST_F로 전환
- TC별로 데이터 세팅 등 중복 동작이 많아서 SetUp / TearDown을 사용할 수 있는 TESF_F로 전환 했습니다.
2. Mock 적용 
- TC에서 모듈 간의 종속성을 끊고자 Mock을 적용했습니다. DataBase와 Printer에 적용하려 했는데 DataBase는 gtest 숙련도가 부족해서 전부 전환하지는 못했습니다.
3. TC 보강
- 각 모듈의 TC를 추가했습니다.

*혹시 gmock관련 빌드 에러가 나실 수도 있는데 패키지 관리자에서 gmock을 설치하셔야 합니다. 기타 환경 이슈는 말씀 해주시면 확인해드리겠습니다